### PR TITLE
Remove symlinks to `cc` and `ld`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository has Dockerfiles to cross-compile Rust programs to different arch
 ## Usage
 To create a release build using cargo, run this command in your Rust root directory (where you normally run 'cargo ...'):
 
-    docker run --rm -v ${PWD}:/work rustcross/__TARGET__:__VERSION__ cargo build --release
+    docker run --rm -v ${PWD}:/work rustcross/__TARGET__:__VERSION__ cargo build --release --target=__TARGET__
     
 Where __TARGET__ is:
 - x86_64-unknown-linux-gnu
@@ -19,6 +19,17 @@ and where __VERSION__ is:
 - 1.12
 
 These versions correspond to Rust versions. 
+
+If you are working with one of the ARM targets, you need to tell cargo to use a custom linker when compiling your code, so create `.cargo/config` and put the following inside:
+
+```
+[target.__TARGET__]
+linker = "arm-linux-gnueabihf-gcc"
+```
+
+Where __TARGET__ is:
+- armv7-unknown-linux-gnueabihf
+- arm-unknown-linux-gnueabihf
 
 ## Source
 These images were created from the cross-build images in https://github.com/dockcross/dockcross.

--- a/arm-unknown-linux-gnueabihf/Dockerfile-1.12
+++ b/arm-unknown-linux-gnueabihf/Dockerfile-1.12
@@ -3,9 +3,7 @@ MAINTAINER Erwin Gribnau "erwin@gribnau.org"
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.12.0-x86_64-unknown-linux-gnu
 RUN /root/.cargo/bin/rustup target add arm-unknown-linux-gnueabihf
-RUN ln -s /usr/bin/arm-linux-gnueabihf-ld /usr/local/sbin/ld && \
-    ln -s /usr/bin/arm-linux-gnueabihf-cc /usr/local/sbin/cc && \
-    ln -s /root/.cargo/bin/cargo /usr/local/sbin/cargo && \
+RUN ln -s /root/.cargo/bin/cargo /usr/local/sbin/cargo && \
     ln -s /root/.cargo/bin/rustc /usr/local/sbin/rustc && \
     ln -s /root/.cargo/bin/rustdoc /usr/local/sbin/rustdoc && \
     ln -s /root/.cargo/bin/rustup /usr/local/sbin/rustup

--- a/arm-unknown-linux-gnueabihf/Dockerfile-latest
+++ b/arm-unknown-linux-gnueabihf/Dockerfile-latest
@@ -3,9 +3,7 @@ MAINTAINER Erwin Gribnau "erwin@gribnau.org"
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN /root/.cargo/bin/rustup target add arm-unknown-linux-gnueabihf
-RUN ln -s /usr/bin/arm-linux-gnueabihf-ld /usr/local/sbin/ld && \
-    ln -s /usr/bin/arm-linux-gnueabihf-cc /usr/local/sbin/cc && \
-    ln -s /root/.cargo/bin/cargo /usr/local/sbin/cargo && \
+RUN ln -s /root/.cargo/bin/cargo /usr/local/sbin/cargo && \
     ln -s /root/.cargo/bin/rustc /usr/local/sbin/rustc && \
     ln -s /root/.cargo/bin/rustdoc /usr/local/sbin/rustdoc && \
     ln -s /root/.cargo/bin/rustup /usr/local/sbin/rustup

--- a/armv7-unknown-linux-gnueabihf/Dockerfile-1.12
+++ b/armv7-unknown-linux-gnueabihf/Dockerfile-1.12
@@ -3,9 +3,7 @@ MAINTAINER Erwin Gribnau "erwin@gribnau.org"
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.12.0-x86_64-unknown-linux-gnu
 RUN /root/.cargo/bin/rustup target add armv7-unknown-linux-gnueabihf
-RUN ln -s /usr/bin/arm-linux-gnueabihf-ld /usr/local/sbin/ld && \
-    ln -s /usr/bin/arm-linux-gnueabihf-cc /usr/local/sbin/cc && \
-    ln -s /root/.cargo/bin/cargo /usr/local/sbin/cargo && \
+RUN ln -s /root/.cargo/bin/cargo /usr/local/sbin/cargo && \
     ln -s /root/.cargo/bin/rustc /usr/local/sbin/rustc && \
     ln -s /root/.cargo/bin/rustdoc /usr/local/sbin/rustdoc && \
     ln -s /root/.cargo/bin/rustup /usr/local/sbin/rustup

--- a/armv7-unknown-linux-gnueabihf/Dockerfile-latest
+++ b/armv7-unknown-linux-gnueabihf/Dockerfile-latest
@@ -3,9 +3,7 @@ MAINTAINER Erwin Gribnau "erwin@gribnau.org"
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 RUN /root/.cargo/bin/rustup target add armv7-unknown-linux-gnueabihf
-RUN ln -s /usr/bin/arm-linux-gnueabihf-ld /usr/local/sbin/ld && \
-    ln -s /usr/bin/arm-linux-gnueabihf-cc /usr/local/sbin/cc && \
-    ln -s /root/.cargo/bin/cargo /usr/local/sbin/cargo && \
+RUN ln -s /root/.cargo/bin/cargo /usr/local/sbin/cargo && \
     ln -s /root/.cargo/bin/rustc /usr/local/sbin/rustc && \
     ln -s /root/.cargo/bin/rustdoc /usr/local/sbin/rustdoc && \
     ln -s /root/.cargo/bin/rustup /usr/local/sbin/rustup


### PR DESCRIPTION
Some crates require intermediate native build steps and these need to be built for the **host**. By symlinking the target specific compilers to `cc` and `ld`, certain crates will fail to build their intermediate steps as they can't find the host compiler.

Instead, we can remove the symlinks and instruct cargo to use the correct linker when building.

(For example, when building with `error-chain` (which depends on `backtrace-sys`) the build will fail without these changes)